### PR TITLE
Pin dependences for default env

### DIFF
--- a/qadabra/workflow/envs/qadabra-default.yaml
+++ b/qadabra/workflow/envs/qadabra-default.yaml
@@ -2,7 +2,7 @@ channels:
     - conda-forge
     - bioconda
 dependencies:
-    - pandas==2.20
+    - pandas==2.2.0
     - numpy==1.26.3
     - matplotlib==3.8.2
     - seaborn==0.13.1

--- a/qadabra/workflow/envs/qadabra-default.yaml
+++ b/qadabra/workflow/envs/qadabra-default.yaml
@@ -2,13 +2,13 @@ channels:
     - conda-forge
     - bioconda
 dependencies:
-    - pandas
-    - numpy
-    - matplotlib
-    - seaborn
-    - scipy
-    - scikit-bio
-    - scikit-learn
-    - bokeh
-    - biom-format
-    - upsetplot
+    - pandas==2.20
+    - numpy==1.26.3
+    - matplotlib==3.8.2
+    - seaborn==0.13.1
+    - scipy==1.11.4
+    - scikit-bio==0.5.8
+    - scikit-learn==1.4.0
+    - bokeh==3.3.3
+    - biom-format==2.1.15
+    - upsetplot==0.8.0


### PR DESCRIPTION
Certain problems were arising due to deprecated functions (see #59). This + a new version on PyPI should (hopefully) resolve.